### PR TITLE
Correct return_previous in OpDel

### DIFF
--- a/txaioetcd/_types.py
+++ b/txaioetcd/_types.py
@@ -798,7 +798,7 @@ class OpDel(Op):
         }
 
         if self.return_previous:
-            obj[u'prev_kv'] = True
+            obj[u'request_delete_range'][u'prev_kv'] = True
 
         return obj
 


### PR DESCRIPTION
The return_previous option gave a HTTP 400 error with the following text:
{"Error":"unknown field \"prev_kv\" in etcdserverpb.RequestOp","Code":3}
because prev_kv was put onto the same level as request_delete_range, however according to the rpc.proto it's an option of request_delete_range, like key.